### PR TITLE
fix: duplicate votes on page refresh after voting

### DIFF
--- a/catrank.go
+++ b/catrank.go
@@ -44,7 +44,13 @@ func main() {
 	}
 
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == "POST" {
+		switch r.Method {
+		case "GET":
+			err := indexTemplate.Execute(w, cats)
+			if err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+		case "POST":
 			catIndexStr := r.FormValue("cat")
 			catIndex, err := strconv.Atoi(catIndexStr)
 			if err == nil {
@@ -56,11 +62,9 @@ func main() {
 					fmt.Println("Error saving cat data:", err)
 				}
 			}
-		}
-
-		err := indexTemplate.Execute(w, cats)
-		if err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
+			http.Redirect(w, r, r.URL.String(), http.StatusSeeOther)
+		default:
+			http.Error(w, "Method Not Allowed", http.StatusMethodNotAllowed)
 		}
 	})
 


### PR DESCRIPTION
When you vote on a cat, then refresh the page, the POST request is sent again, causing a duplicate vote. This behavior happens every time you refresh after voting at least once.

These changes add a redirect response to the POST response after completing the request. They also add a `MethodNotAllowed` HTTP status code as a default to the request handler.