### PR TITLE
feat: add cats data storage initialization

### DIFF
--- a/cats.json
+++ b/cats.json
@@ -2,17 +2,17 @@
   {
     "Name": "Susanna",
     "ImageURL": "",
-    "Votes": 4
+    "Votes": 0
   },
   {
     "Name": "Walter",
     "ImageURL": "",
-    "Votes": 3
+    "Votes": 0
   },
   {
     "Name": "Pan-Pan",
     "ImageURL": "",
-    "Votes": 8
+    "Votes": 0
   },
   {
     "Name": "Busby",
@@ -22,6 +22,6 @@
   {
     "Name": "Keaton",
     "ImageURL": "",
-    "Votes": 1
+    "Votes": 0
   }
 ]


### PR DESCRIPTION
This also removes the `cats` global variable

An important note about these changes is that it looks for an environment variable called `CATS_DATA_PATH` for the path to the cats json file and will default to `/data/cats.json` if `CATS_DATA_PATH` is not set. In theory, the default path _should_ be the path to the file in production, but I'm not entirely sure about that